### PR TITLE
Added mit license and description

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,2 +1,3 @@
 ^placeholder\.Rproj$
 ^\.Rproj\.user$
+^LICENSE\.md$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Authors@R:
            family = "Helmich",
            role = c("aut"),
            email = "sam.helmich@gmail.com")
-Description: What the package does (one paragraph).
-License: What license it uses
+Description: A package for interfacing with Docker from R, including generating dockerfiles and allowing users to build/push/tag/run docker images.
+License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,2 @@
+YEAR: 2019
+COPYRIGHT HOLDER: Sam Helmich; Ellis Valentiner; Amanda Gadrow; Ben Crary

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+# MIT License
+
+Copyright (c) 2019 Sam Helmich; Ellis Valentiner; Amanda Gadrow; Ben Crary
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Added MIT license with copyright to all four inceptors - Sam Helmich, Ellis Valentiner, Amanda Gadrow, and Ben Crary. Gave a very basic description in the namespace file